### PR TITLE
[CI] Automatically build logo collections

### DIFF
--- a/.github/workflows/build-collection.yml
+++ b/.github/workflows/build-collection.yml
@@ -1,0 +1,57 @@
+name: Build logo collection
+
+on:
+  # Build on pushes to main if the orgnames file changes in the commit
+  push:
+    branches: [ main ]
+    paths:
+      - 'orgnames'
+
+  # Allows you to trigger a build manually through the Actions tab
+  workflow_dispatch:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download logos
+        run: ./get_logos.sh
+      
+      - name: Generate tag name
+        id: tagname
+        run: echo "::set-output name=tagname::$(date -u +"%Y-%m-%dT%H%M%SZ")"
+      
+      - name: Create a release
+        id: create-release
+        uses: actions/create-release@v1
+        with:
+          tag_name: release-${{ steps.tagname.outputs.tagname }}
+          release_name: Release ${{ steps.tagname.outputs.tagname }}
+          body: Based on ${{ github.sha }}
+      
+      - name: Create archives of logos
+        run: |
+          zip -r logos.zip logos
+          tar czvf logos.tar.gz logos
+
+      - name: Upload logos.zip as release artifact
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./logos.zip
+          asset_name: logos.zip
+          asset_content_type: application/zip
+      
+      - name: Upload logos.tar.gz as release artifact
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./logos.tar.gz
+          asset_name: logos.tar.gz
+          asset_content_type: application/x-gtar

--- a/get_logos.sh
+++ b/get_logos.sh
@@ -6,5 +6,10 @@ GH_USER=`cat github_user`
 GH_TOKEN=`cat github_token`
 for o in `cat orgnames`; do
     echo "Downloading $o.png";
-    curl -s -u $GH_USER:$GH_TOKEN -L -o logos/$o.png https://github.com/$o.png
+    # During CI runs, use a GitHub App token rather than a Personal Access Token
+    if [[ $CI = "true" ]]; then
+        curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -L -o logos/$o.png https://github.com/$o.png
+    else
+        curl -s -u $GH_USER:$GH_TOKEN -L -o logos/$o.png https://github.com/$o.png
+    fi
 done


### PR DESCRIPTION
This adds an Actions workflow that creates a release for every push to `main` that changes the `orgnames` file. It'll attach a zipped and a tar'd copy of the `logos/` folder to the release.

You can see it work on my fork of this repo:
- Show that it's triggered properly: https://github.com/SaschaMann/JuliaOrgLogos/commits/main
- What the release looks like: https://github.com/SaschaMann/JuliaOrgLogos/releases
  - (I tweaked the workflow a bit, the last two commits are representative of what they should look like)

It does _not_ update the `logos/` folder itself, though. If that's something you want, I can add it in a follow-up PR.

This doesn't quite solve the comment in the README but one could attach code that generates a pretty collection beneath it. I still think it's quite useful to download all logos at once without cloning the repo and rerunning the script.