### PR TITLE
[CI] Update logos/ dir if necessary

### DIFF
--- a/.github/workflows/build-collection.yml
+++ b/.github/workflows/build-collection.yml
@@ -6,6 +6,8 @@ on:
     branches: [ main ]
     paths:
       - 'orgnames'
+      - 'logos/*'
+      - '.github/workflows/build-collection.yml'
 
   # Allows you to trigger a build manually through the Actions tab
   workflow_dispatch:
@@ -23,6 +25,23 @@ jobs:
       - name: Download logos
         run: ./get_logos.sh
       
+      - name: Commit & push changes if there are any
+        run: |
+          # Check if there is nothing to commit (i.e. no logos are missing from logos/)
+          if [[ -z $(git status --porcelain) ]]; then
+              echo "logos directory is up-to-date already"
+              exit 0
+          fi
+
+          # Configure git
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+          # Commit the changes
+          git add .
+          git commit -m "[CI] Update logos"
+          git push
+
       - name: Generate tag name
         id: tagname
         run: echo "::set-output name=tagname::$(date -u +"%Y-%m-%dT%H%M%SZ")"


### PR DESCRIPTION
This will fix the following:

> Thanks! I think it would be nice to update the logos folder itself. I think the file sizes are all going to be small enough that it'll be ok to do so.

It does not update PR branches to avoid permission issues but instead commits to `main` if necessary after a PR has been merged.

Example run:
- The commit that was added after a PR added an org: https://github.com/SaschaMann/JuliaOrgLogos/commits/main
- The corresponding release: https://github.com/SaschaMann/JuliaOrgLogos/releases/tag/release-2020-11-21T130315Z